### PR TITLE
fix: emit X-Glean-Include-Experimental header (not X-Glean-Experimental)

### DIFF
--- a/src/main/java/com/glean/api_client/glean_api_client/hooks/XGleanHeadersHook.java
+++ b/src/main/java/com/glean/api_client/glean_api_client/hooks/XGleanHeadersHook.java
@@ -17,7 +17,7 @@ import java.util.function.Function;
  * <p>This hook sets the following headers based on SDK options or environment variables:
  * <ul>
  *   <li>{@code X-Glean-Exclude-Deprecated-After} - Exclude API endpoints deprecated after this date</li>
- *   <li>{@code X-Glean-Experimental} - Enable experimental API features</li>
+ *   <li>{@code X-Glean-Include-Experimental} - Enable experimental API features</li>
  * </ul>
  *
  * <p>Environment variables take precedence over SDK constructor options:
@@ -32,7 +32,7 @@ public final class XGleanHeadersHook {
     static final String ENV_INCLUDE_EXPERIMENTAL = "X_GLEAN_INCLUDE_EXPERIMENTAL";
 
     static final String HEADER_EXCLUDE_DEPRECATED_AFTER = "X-Glean-Exclude-Deprecated-After";
-    static final String HEADER_EXPERIMENTAL = "X-Glean-Experimental";
+    static final String HEADER_EXPERIMENTAL = "X-Glean-Include-Experimental";
 
     private XGleanHeadersHook() {
         // prevent instantiation


### PR DESCRIPTION
## Summary

The `XGleanHeadersHook` `BeforeRequest` hook correctly reads the `includeExperimental` SDK option and the `X_GLEAN_INCLUDE_EXPERIMENTAL` env var, but sets the **wrong header name**. It emits `X-Glean-Experimental` when the backend expects **`X-Glean-Include-Experimental`**.

This corrects the `HEADER_EXPERIMENTAL` constant (and javadoc). Behavior (opt-in, env var precedence) is unchanged. The test references the constant, so it's covered automatically.

## Changes
- `src/main/java/.../hooks/XGleanHeadersHook.java` — header constant value and javadoc

## Verification
- `./gradlew test --tests "*XGleanHeadersHookTest*"` → BUILD SUCCESSFUL

## Related
Same bug exists in the TypeScript, Go, and Python SDKs; companion PRs fix each. Env var name was already correct and is unchanged.
